### PR TITLE
Deserialize nullable with null value

### DIFF
--- a/FileContextCore/Serializer/SerializerHelper.cs
+++ b/FileContextCore/Serializer/SerializerHelper.cs
@@ -13,12 +13,12 @@ namespace FileContextCore.Serializer
     {
         public static object Deserialize(this string input, Type type)
         {
-	        type = Nullable.GetUnderlyingType(type) ?? type;
-
             if (string.IsNullOrEmpty(input))
             {
                 return type.GetDefaultValue();
             }
+
+	    type = Nullable.GetUnderlyingType(type) ?? type;
 
             if (type == typeof(DateTimeOffset))
             {


### PR DESCRIPTION
When the type being deserialized has an empty string value it return de default value of the underlying type instead of null