### PR TITLE
Adding deserialization support for Enums

### DIFF
--- a/FileContextCore/Serializer/SerializerHelper.cs
+++ b/FileContextCore/Serializer/SerializerHelper.cs
@@ -48,6 +48,10 @@ namespace FileContextCore.Serializer
                 return arr.ToArray();
             }
             
+            if (type.IsEnum)
+            {
+                return Enum.Parse(type, input);
+            }
 
             return Convert.ChangeType(input, type, CultureInfo.InvariantCulture);
         }


### PR DESCRIPTION
Fix: deserializing a entity containing enum throw "InvalidCastException: Invalid cast from 'System.String' to '<EnumType>'."