### PR TITLE
Change to .net standard 2.0

### DIFF
--- a/ASPNETDemo/ASPNETDemo.csproj
+++ b/ASPNETDemo/ASPNETDemo.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ASPNETDemo/ASPNETDemo.csproj
+++ b/ASPNETDemo/ASPNETDemo.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FileContextCore/Check.cs
+++ b/FileContextCore/Check.cs
@@ -97,7 +97,7 @@ namespace FileContextCore.Utilities
         }
 
         [Conditional("DEBUG")]
-        public static void DebugAssert([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] bool condition, string message)
+        public static void DebugAssert(bool condition, string message)
         {
             if (!condition)
             {

--- a/FileContextCore/FileContextCore.csproj
+++ b/FileContextCore/FileContextCore.csproj
@@ -28,8 +28,8 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="15.0.5" />
     <PackageReference Include="EPPlus" Version="5.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/FileContextCore/FileContextCore.csproj
+++ b/FileContextCore/FileContextCore.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <SignAssembly Condition="'$(OS)' == 'Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile>FileContextCoreCert.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -25,11 +26,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="12.1.3" />
-    <PackageReference Include="EPPlus" Version="4.5.3.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="CsvHelper" Version="15.0.5" />
+    <PackageReference Include="EPPlus" Version="5.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>

--- a/FileContextCore/FileContextCore.csproj
+++ b/FileContextCore/FileContextCore.csproj
@@ -6,7 +6,7 @@
     <SignAssembly Condition="'$(OS)' == 'Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile>FileContextCoreCert.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <Company>morrisjdev</Company>
     <Authors>morrisjdev</Authors>
     <Description>File provider for Entity Framework Core (to be used for development purposes)</Description>
@@ -20,8 +20,8 @@
     <PackageProjectUrl>https://github.com/morrisjdev/FileContextCore</PackageProjectUrl>
     <NeutralLanguage>en-US</NeutralLanguage>
     <DelaySign>false</DelaySign>
-    <AssemblyVersion>3.3.0.0</AssemblyVersion>
-    <FileVersion>3.3.0.0</FileVersion>
+    <AssemblyVersion>3.4.0.0</AssemblyVersion>
+    <FileVersion>3.4.0.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/FileContextCore/Serializer/CSVSerializer.cs
+++ b/FileContextCore/Serializer/CSVSerializer.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using FileContextCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using System.Globalization;
 
 namespace FileContextCore.Serializer
 {
@@ -34,7 +34,7 @@ namespace FileContextCore.Serializer
             }
 
             TextReader tr = new StringReader(list);
-            CsvReader reader = new CsvReader(tr);
+            CsvReader reader = new CsvReader(tr, CultureInfo.CurrentCulture);
 
             reader.Read();
             reader.ReadHeader();
@@ -61,7 +61,7 @@ namespace FileContextCore.Serializer
         public string Serialize<TKey>(Dictionary<TKey, object[]> list)
         {
             StringWriter sw = new StringWriter();
-            CsvWriter writer = new CsvWriter(sw);
+            CsvWriter writer = new CsvWriter(sw, CultureInfo.CurrentCulture);
 
             for (int i = 0; i < _propertyKeys.Length; i++)
             {

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Feel free to create a PR with your new provider and I'll add it to FileContextCo
 
 | FileContext Version | EF Core Version |
 |---------------------|-----------------|
+| 3.4.*              | 3.1.0           |
 | 3.3.*              | 3.0.0           |
 | 3.2.*              | 3.0.0           |
 | 3.0.1/3.0.0/2.2.6   | 2.2.6           |


### PR DESCRIPTION
Since this library is not really dependent on .net standard 2.1 it should target 2.0.
Ef Core, and every other dependency is 2.0 compatible and so should be this library.
This pr also enables using the newest version of this library on .NetFramework

- Update EF Core to 3.1.0 and other dependencies
- Add langversion 8.0 since this is .net standard 2.0 [some](https://stackoverflow.com/questions/56651472/does-c-sharp-8-support-the-net-framework) c# 8 features won't work
- Fix csvhelper usage (currently it's using CurrentCulture should it use Invariant?)
- Remove only non useable attribute after downgrade to netstandard 2.0
- Bump package version 3.4.0