### PR TITLE
Update CSVHelper to 21.1.0

### DIFF
--- a/FileContextCore/FileContextCore.csproj
+++ b/FileContextCore/FileContextCore.csproj
@@ -6,7 +6,7 @@
     <SignAssembly Condition="'$(OS)' == 'Windows_NT'">true</SignAssembly>
     <AssemblyOriginatorKeyFile>FileContextCoreCert.snk</AssemblyOriginatorKeyFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <Company>morrisjdev</Company>
     <Authors>morrisjdev</Authors>
     <Description>File provider for Entity Framework Core (to be used for development purposes)</Description>
@@ -20,8 +20,8 @@
     <PackageProjectUrl>https://github.com/morrisjdev/FileContextCore</PackageProjectUrl>
     <NeutralLanguage>en-US</NeutralLanguage>
     <DelaySign>false</DelaySign>
-    <AssemblyVersion>3.4.0.0</AssemblyVersion>
-    <FileVersion>3.4.0.0</FileVersion>
+    <AssemblyVersion>3.4.1.0</AssemblyVersion>
+    <FileVersion>3.4.1.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/FileContextCore/FileContextCore.csproj
+++ b/FileContextCore/FileContextCore.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="15.0.5" />
+    <PackageReference Include="CsvHelper" Version="21.1.0" />
     <PackageReference Include="EPPlus" Version="5.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />


### PR DESCRIPTION
When using CSVHelper independently from FileContextCore, with a higher version than 20.0.0 using this library on Unity with the IL2CPP backend then, when converting the for the build it will fail due to mismatching methods. Updating the CSVHelper to recent version fixes this problem. As far as I see it should not produce any regression, as the new features are not utilised by FileContextCore