### PR TITLE
Dirty fix to support .NET6 and .NET7

### DIFF
--- a/FileContextCore/Query/Internal/FileContextLinqOperatorProvider.cs
+++ b/FileContextCore/Query/Internal/FileContextLinqOperatorProvider.cs
@@ -128,7 +128,15 @@ namespace FileContextCore.Query.Internal
         static FileContextLinqOperatorProvider()
         {
             var enumerableMethods = typeof(Enumerable).GetTypeInfo()
-                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly).ToList();
+                .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(x => x.GetParameters().Aggregate(true,
+                    (prev, p) => prev && p.ParameterType.ToString() switch
+                    {
+                        "System.Index" => false,
+                        "System.Range" => false,
+                        _ => true
+                    }))
+                .ToList();
 
             AsEnumerable = enumerableMethods.Single(
                 mi => mi.Name == nameof(Enumerable.AsEnumerable) && mi.IsGenericMethod && mi.GetParameters().Length == 1);


### PR DESCRIPTION
Quick and dirty fix to support .NET6 and .NET7 when keeping EFCore version as is.

I haven't run massive tests but at least simple query doesn't throw when running on .NET6 or .NET7
I think this would fix #40 

Before fix `FileContextLinqOperatorProvider` static constructor would throw following exception when trying query from simple dbset:

```
      System.TypeInitializationException: The type initializer for 'FileContextCore.Query.Internal.FileContextLinqOperatorProvider' threw an exception.
       ---> System.InvalidOperationException: Sequence contains more than one matching element
         at System.Linq.ThrowHelper.ThrowMoreThanOneMatchException()
         at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
         at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source, Func`2 predicate)
         at FileContextCore.Query.Internal.FileContextLinqOperatorProvider..cctor() in C:\source\...\FileContextCore\FileContextCore\Query\Internal\FileContextLinqOperatorProvider.cs:line 175
```